### PR TITLE
Hardware property class

### DIFF
--- a/abstract/imaging_device.py
+++ b/abstract/imaging_device.py
@@ -1,18 +1,33 @@
 # extended from https://gist.github.com/HazenBabcock/8d1042f564dcaee60c3a3972f2d56999
 
 
+class HWPropertyValueError(Exception):
+    pass
+
+
 class HWProperty(object):
     """Defines a hardware property.
     """
-    def __init__(self, name = None, value = None, limits = None, values = None, writable = None, readable = None, **kwds):
+    def __init__(self,
+                 name = None,
+                 value = None,
+                 description = None,
+                 ptype = None,
+                 readable = None,
+                 writable = None,
+                 values = None,
+                 limits = None,
+                 **kwds):
         super().__init(**kwds)
 
         self._name = name
         self._value = value
-        self._limits = limits
-        self._values = values
-        self._writable = writable
+        self._description = description
+        self._ptype = ptype
         self._readable = readable
+        self._writable = writable
+        self._values = values
+        self._limits = limits
 
     @property
     def name(self):
@@ -34,21 +49,36 @@ class HWProperty(object):
         if not self.is_valid(new_value):
             raise HWPropertyValueError(str(new_value) + " is not allowed.")
         
-
     @property
-    def limits(self):
-        """Limits on the range of the property.
+    def description(self):
+        """A string that describes the property.
 
-        Usually this a list [low, high], or none if there are no limits.
+        This is a string describing the purpose of the property, for example
+        'camera frame rate in frames per second'.
         """
 
     @property
-    def values(self):
-        """Allowed values for a property.
+    def ptype(self):
+        """Type of the property (float, int, bool, str, etc..)
 
-        Usually this is a list of allowed values, or none if any value is allowed.
+        This is the type of the property, for example a floating point number
+        or an integer. Usually these are basic Python types, but numpy arrays
+        or even 'object' are also allowed.
+
+        FIXME: Any value in making this work with isinstance()? So for example 
+               the user could use 'isinstance(hw_property, float)' and this 
+               would return True of this was a floating point property? Or is 
+               this just a bad idea?
         """
+        
+    @property
+    def readable(self):
+        """Is the property readable?
 
+        This is a boolean. Do we have a use case for these kinds of properties? Do
+        people use unreadable properties?
+        """
+        
     @property
     def writable(self):
         """Is the property writable?
@@ -57,13 +87,19 @@ class HWProperty(object):
         """
 
     @property
-    def readable(self):
-        """Is the property readable?
+    def values(self):
+        """Allowed values for a property.
 
-        This is a boolean. Do we have a use case for these kinds of properties? Do
-        people use unreadable properties?
+        Usually this is a list of allowed values, or none if any value is allowed.
         """
+        
+    @property
+    def limits(self):
+        """Limits on the range of the property.
 
+        Usually this a list [low, high], or none if there are no limits.
+        """
+        
     def is_valid(self, value):
         """Returns True is value is a valid setting for the property.
 

--- a/abstract/imaging_device.py
+++ b/abstract/imaging_device.py
@@ -8,7 +8,7 @@ class ImageData(object):
         self._data = data
         self._meta = meta
 
-    @proeprty
+    @property
     def data(self):
         """Image data array for this frame.
 

--- a/abstract/imaging_device.py
+++ b/abstract/imaging_device.py
@@ -29,6 +29,12 @@ class HWProperty(object):
         Python object.
         """
 
+    @value.setter
+    def value(self, new_value):
+        if not self.is_valid(new_value):
+            raise HWPropertyValueError(str(new_value) + " is not allowed.")
+        
+
     @property
     def limits(self):
         """Limits on the range of the property.
@@ -127,6 +133,7 @@ class ImagingDevice(object):
             Uniquely identifies the camera to open. The type of this object is defined by the 
             ImagingDevice subclass.
         """
+        self.properties_used = {}
 
     def open():
         # open camera
@@ -135,21 +142,24 @@ class ImagingDevice(object):
         # Shutdown / clean up.
         
     def get_properties(self, property_names):
-        """Return a dictionary of {'property_name': value} for the list of properties requested.
+        """Return a dictionary of {'property_name': HWProperty} for the list of properties requested.
         """
+        for elt in property_names:
+            prop = .. # Create property with current value.
+            p_dict[elt] = prop
+
+            # Add to record of properties of interest.
+            if not elt in self.properties_used:
+                self.properties_used[elt] = prop
+
+        return p_dict
         
     def get_property_info(self):
         """Return information about all properties supported by this device
 
         Return format is::
 
-            { 'property_name': {
-                'type': 'int'|'float', 
-                'limits': [min, max], 
-                'values': [list of accepted values], 
-                'writable': bool, 
-                'readable': bool },
-            }
+            { 'property_name': HWProperty }
 
         Some property names are standardized across all cameras (although cameras need not
         support all of these):
@@ -193,16 +203,17 @@ class ImagingDevice(object):
 
         Parameters
         ----------
-        properties : dict
-            Contains {'property_name': value} pairs to be set. May be OrderedDict in cases where
+        properties : dict or list
+            dict: Contains {'property_name': value} pairs to be set. May be OrderedDict in cases where
             properties must be set in a specific order.
+            list: A list of HWProperty objects.
 
         Returns
         -------
         need_restart : bool
             Indicates whether acquisition must be restarted before new values take effect
         new_values : dict
-            Contains {'property_name': value} for each property that was set. In some cases,
+            Contains {'property_name': HWProperty} for each property that was set. In some cases,
             the value returned here will differ from the one requested. May also contain
             the values of properties that were indirectly changed as a result of this
             request.
@@ -210,7 +221,36 @@ class ImagingDevice(object):
             A list of properties that may have changed results from get_property_info as
             a result of this request. This allows user interfaces to update dynamically as needed.
         """
-        
+        new_values = {}
+        for elt in properties:
+            if isinstance(elt, HWProperty):
+                # update based on elt.value
+            else:
+                # update based on properties[elt]
+
+            # Query updated value.
+            prop = .. # Create property with current value.
+            new_values[elt] = prop
+
+            # Add to record of properties that the user specifically requested.
+            #
+            # FIXME? Need to do something here so that this property also gets picked up
+            #        as changed?
+            if not elt in self.properties_used:
+                self.properties_used[elt] = prop
+
+        # Check for changes in the properties that the user is tracking.
+        #
+        # FIXME? Some properties are going to be queried multiple times which may not
+        #        be efficient. Perhaps 'new_values' and 'info_changed' are mutually
+        #        exclusive?
+        #
+        changed = {}
+        for elt in self.properties_used:
+            prop = .. # Create property with current value.
+            if (prop.value != self.properties_used[elt].value):
+                changed[elt] = prop
+    
     def get_images(self, max_count=None):
         """Return ImageData instances that have accumulated since the last call to get_images().
 

--- a/abstract/imaging_device.py
+++ b/abstract/imaging_device.py
@@ -1,6 +1,71 @@
 # extended from https://gist.github.com/HazenBabcock/8d1042f564dcaee60c3a3972f2d56999
 
 
+class HWProperty(object):
+    """Defines a hardware property.
+    """
+    def __init__(self, name = None, value = None, limits = None, values = None, writable = None, readable = None, **kwds):
+        super().__init(**kwds)
+
+        self._name = name
+        self._value = value
+        self._limits = limits
+        self._values = values
+        self._writable = writable
+        self._readable = readable
+
+    @property
+    def name(self):
+        """Name of the property.
+
+        This is a string.
+        """
+
+    @property
+    def value(self):
+        """Current value of the property.
+
+        Usually this is a string or a number but it could also be an array or any
+        Python object.
+        """
+
+    @property
+    def limits(self):
+        """Limits on the range of the property.
+
+        Usually this a list [low, high], or none if there are no limits.
+        """
+
+    @property
+    def values(self):
+        """Allowed values for a property.
+
+        Usually this is a list of allowed values, or none if any value is allowed.
+        """
+
+    @property
+    def writable(self):
+        """Is the property writable?
+
+        This is boolean.
+        """
+
+    @property
+    def readable(self):
+        """Is the property readable?
+
+        This is a boolean. Do we have a use case for these kinds of properties? Do
+        people use unreadable properties?
+        """
+
+    def is_valid(self, value):
+        """Returns True is value is a valid setting for the property.
+
+        This is also used internally based on the values of limits and values to
+        enforce valid settings.
+        """
+        
+
 class ImageData(object):
     """Contains information about one or more acquired frames. 
     """

--- a/abstract/imaging_device.py
+++ b/abstract/imaging_device.py
@@ -10,7 +10,6 @@ class HWProperty(object):
     """
     def __init__(self,
                  name = None,
-                 value = None,
                  description = None,
                  ptype = None,
                  readable = None,
@@ -21,7 +20,6 @@ class HWProperty(object):
         super().__init(**kwds)
 
         self._name = name
-        self._value = value
         self._description = description
         self._ptype = ptype
         self._readable = readable
@@ -29,25 +27,15 @@ class HWProperty(object):
         self._values = values
         self._limits = limits
 
+    def __eq__(self, other):
+        ...
+        
     @property
     def name(self):
         """Name of the property.
 
         This is a string.
         """
-
-    @property
-    def value(self):
-        """Current value of the property.
-
-        Usually this is a string or a number but it could also be an array or any
-        Python object.
-        """
-
-    @value.setter
-    def value(self, new_value):
-        if not self.is_valid(new_value):
-            raise HWPropertyValueError(str(new_value) + " is not allowed.")
         
     @property
     def description(self):
@@ -178,22 +166,25 @@ class ImagingDevice(object):
         # Shutdown / clean up.
         
     def get_properties(self, property_names):
-        """Return a dictionary of {'property_name': HWProperty} for the list of properties requested.
+        """Return a dictionary of {'property_name': value} for the list of properties requested.
         """
+        p_dict = {}
         for elt in property_names:
-            prop = .. # Create property with current value.
-            p_dict[elt] = prop
+            value = .. # Get current value.
+            p_dict[elt] = value
 
             # Add to record of properties of interest.
             if not elt in self.properties_used:
+                prop = .. # Get current info
                 self.properties_used[elt] = prop
 
         return p_dict
         
-    def get_property_info(self):
-        """Return information about all properties supported by this device
+    def get_properties_info(self, property_names):
+        """Return a dictionary of {'property_name': HWProperty} for the list of properties requested.
 
-        Return format is::
+        If 'property_names' is None then information about all properties supported by this device
+        are returned.
 
             { 'property_name': HWProperty }
 
@@ -239,54 +230,49 @@ class ImagingDevice(object):
 
         Parameters
         ----------
-        properties : dict or list
+        properties : dict
             dict: Contains {'property_name': value} pairs to be set. May be OrderedDict in cases where
             properties must be set in a specific order.
-            list: A list of HWProperty objects.
 
         Returns
         -------
         need_restart : bool
             Indicates whether acquisition must be restarted before new values take effect
         new_values : dict
-            Contains {'property_name': HWProperty} for each property that was set. In some cases,
+            Contains {'property_name': value} for each property that was set. In some cases,
             the value returned here will differ from the one requested. May also contain
             the values of properties that were indirectly changed as a result of this
             request.
         info_changed : list
-            A list of properties that may have changed results from get_property_info as
-            a result of this request. This allows user interfaces to update dynamically as needed.
+            A list of the names of the properties who information might have changed, for
+            example their allowed range. Use 'get_properties_info' to query for the 
+            updated information. This allows user interfaces to update dynamically as needed.
         """
+        need_restart = False
         new_values = {}
         for elt in properties:
-            if isinstance(elt, HWProperty):
-                # update based on elt.value
-            else:
-                # update based on properties[elt]
+            # update based on properties[elt]
 
             # Query updated value.
-            prop = .. # Create property with current value.
-            new_values[elt] = prop
+            value = ..
+            new_values[elt] = value
 
             # Add to record of properties that the user specifically requested.
             #
-            # FIXME? Need to do something here so that this property also gets picked up
-            #        as changed?
             if not elt in self.properties_used:
-                self.properties_used[elt] = prop
+                self.properties_used[elt] = True
 
         # Check for changes in the properties that the user is tracking.
         #
-        # FIXME? Some properties are going to be queried multiple times which may not
-        #        be efficient. Perhaps 'new_values' and 'info_changed' are mutually
-        #        exclusive?
-        #
-        changed = {}
+        info_changed = {}
         for elt in self.properties_used:
             prop = .. # Create property with current value.
-            if (prop.value != self.properties_used[elt].value):
+            if (prop != self.properties_used[elt]):
                 changed[elt] = prop
-    
+                self.properties_used[elt] = prop
+
+        return [need_restart, new_values, info_changed]
+
     def get_images(self, max_count=None):
         """Return ImageData instances that have accumulated since the last call to get_images().
 


### PR DESCRIPTION
Changes:
* Add a hardware property class `HWProperty` that is used for querying and setting camera properties.
* Change `ImagingDevice` to use the `HWProperty` class.
* Change `ImagingDevice` to keep track of the properties the user is interested in as determined by the values passed to `get_properties` and `set_properties`.
